### PR TITLE
ALP dissector was merged to upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# ALP dissector was merged to upstream. It is available in nightly builds and will be available in v4.1
+
 General Information
 -------------------
 


### PR DESCRIPTION
Hi Nick

I've sent your ALP dissector to Wireshark main repo. Also I added LMT, Sony header extensions and LLS dissectors. All three are merged so this repo is not actual anymore

https://gitlab.com/wireshark/wireshark/-/blob/master/epan/dissectors/packet-alp.c (ALP + LMT + Sony header extensions)
https://gitlab.com/wireshark/wireshark/-/blob/master/epan/dissectors/packet-lls.c (LLS)